### PR TITLE
Unused declaration and import misplaced

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,7 +9,6 @@ disabled_rules: # rule identifiers to exclude from running
   - switch_case_alignment
   - todo
 opt_in_rules: # some rules are only opt-in
-  - anyobject_protocol
   - attributes
   - closure_body_length
   - closure_end_indentation

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -73,8 +73,6 @@ opt_in_rules: # some rules are only opt-in
   - unavailable_function
   - unneeded_parentheses_in_closure_argument
   - unowned_variable_capture
-  - unused_declaration
-  - unused_import
   - vertical_parameter_alignment_on_call
   - vertical_whitespace_closing_braces
   - vertical_whitespace_opening_braces
@@ -91,6 +89,8 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Source/*/ExcludedFile.swift # Exclude files with a wildcard
 analyzer_rules: # Rules run by `swiftlint analyze` (experimental)
   - explicit_self
+  - unused_declaration
+  - unused_import
 # configurable rules can be customized from this configuration file
 # binary rules can set their severity level
 closure_body_length:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,6 +2,7 @@ disabled_rules: # rule identifiers to exclude from running
   - control_statement
   - required_deinit
   - explicit_acl
+  - explicit_top_level_acl
   - orphaned_doc_comment
   - overridden_super_call
   - private_over_fileprivate
@@ -28,7 +29,6 @@ opt_in_rules: # some rules are only opt-in
   - enum_case_associated_values_count
   - expiring_todo
   - explicit_init
-  - explicit_top_level_acl
   - explicit_type_interface
   - fallthrough
   - fatal_error_message


### PR DESCRIPTION
Moving unused_declaration and unused_import to the analyzer rules section in the config file